### PR TITLE
make ByteSlicePool a *Pool, not a Pool.

### DIFF
--- a/mpool/pool.go
+++ b/mpool/pool.go
@@ -26,12 +26,10 @@ import (
 )
 
 // ByteSlicePool is a static Pool for reusing byteslices of various sizes.
-var ByteSlicePool Pool
-
-func init() {
-	ByteSlicePool.New = func(length int) interface{} {
+var ByteSlicePool = &Pool{
+	New: func(length int) interface{} {
 		return make([]byte, length)
-	}
+	},
 }
 
 // MaxLength is the maximum length of an element that can be added to the Pool.

--- a/mpool/pool_test.go
+++ b/mpool/pool_test.go
@@ -162,7 +162,7 @@ func TestPoolStressByteSlicePool(t *testing.T) {
 	if testing.Short() {
 		N /= 100
 	}
-	p := &ByteSlicePool
+	p := ByteSlicePool
 	done := make(chan bool)
 	errs := make(chan error)
 	for i := 0; i < P; i++ {


### PR DESCRIPTION
This way, copying it won't copy the underlying pool.

Also, initialize it immediately instead of in an `init` function to ensure that it's fully initialized immediately.