### PR TITLE
don't hold the lock when closing

### DIFF
--- a/msgio.go
+++ b/msgio.go
@@ -105,9 +105,6 @@ func (s *writer) WriteMsg(msg []byte) (err error) {
 }
 
 func (s *writer) Close() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if c, ok := s.W.(io.Closer); ok {
 		return c.Close()
 	}
@@ -216,9 +213,6 @@ func (s *reader) ReleaseMsg(msg []byte) {
 }
 
 func (s *reader) Close() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if c, ok := s.R.(io.Closer); ok {
 		return c.Close()
 	}

--- a/msgio_test.go
+++ b/msgio_test.go
@@ -33,6 +33,20 @@ func TestReadWriteMsgSync(t *testing.T) {
 	SubtestReadWriteMsgSync(t, writer, reader)
 }
 
+func TestReadClose(t *testing.T) {
+	r, w := io.Pipe()
+	writer := NewWriter(w)
+	reader := NewReader(r)
+	SubtestReadClose(t, writer, reader)
+}
+
+func TestWriteClose(t *testing.T) {
+	r, w := io.Pipe()
+	writer := NewWriter(w)
+	reader := NewReader(r)
+	SubtestWriteClose(t, writer, reader)
+}
+
 func SubtestReadWrite(t *testing.T, writer WriteCloser, reader ReadCloser) {
 	msgs := [1000][]byte{}
 
@@ -197,11 +211,8 @@ func TestBadSizes(t *testing.T) {
 	_ = msg
 }
 
-func TestReadClose(t *testing.T) {
-	r, w := io.Pipe()
-	writer := NewWriter(w)
+func SubtestReadClose(t *testing.T, writer WriteCloser, reader ReadCloser) {
 	defer writer.Close()
-	reader := NewReader(r)
 
 	buf := [10]byte{}
 	done := make(chan struct{})
@@ -217,10 +228,7 @@ func TestReadClose(t *testing.T) {
 	<-done
 }
 
-func TestWriteClose(t *testing.T) {
-	r, w := io.Pipe()
-	writer := NewWriter(w)
-	reader := NewReader(r)
+func SubtestWriteClose(t *testing.T, writer WriteCloser, reader ReadCloser) {
 	defer reader.Close()
 
 	buf := [10]byte{}

--- a/varint.go
+++ b/varint.go
@@ -49,9 +49,6 @@ func (s *varintWriter) WriteMsg(msg []byte) error {
 }
 
 func (s *varintWriter) Close() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if c, ok := s.W.(io.Closer); ok {
 		return c.Close()
 	}
@@ -162,9 +159,6 @@ func (s *varintReader) ReleaseMsg(msg []byte) {
 }
 
 func (s *varintReader) Close() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if c, ok := s.R.(io.Closer); ok {
 		return c.Close()
 	}

--- a/varint_test.go
+++ b/varint_test.go
@@ -3,6 +3,7 @@ package msgio
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
 	"testing"
 )
 
@@ -63,4 +64,18 @@ func SubtestVarintWrite(t *testing.T, msg []byte) {
 	if len(bb) != bblen {
 		t.Fatalf("wrote incorrect number of bytes: %d != %d", len(bb), bblen)
 	}
+}
+
+func TestVarintReadClose(t *testing.T) {
+	r, w := io.Pipe()
+	writer := NewVarintWriter(w)
+	reader := NewVarintReader(r)
+	SubtestReadClose(t, writer, reader)
+}
+
+func TestVarintWriteClose(t *testing.T) {
+	r, w := io.Pipe()
+	writer := NewVarintWriter(w)
+	reader := NewVarintReader(r)
+	SubtestWriteClose(t, writer, reader)
 }


### PR DESCRIPTION
In libp2p, Close is assumed to be threadsafe and we'd like to interrupt in-progress reads/writes.

As a matter of fact, we're lucky this hasn't caused close to hang permanently (it still hangs occasionally, just for a bounded amount of time). If we had tried to close the reader before closing the writer, we would have blocked on a concurrent read call.

fixes #8