### PR TITLE
Allow sizing internal bufio reader in protoio

### DIFF
--- a/protoio/uvarint_reader.go
+++ b/protoio/uvarint_reader.go
@@ -59,7 +59,9 @@ func NewDelimitedReader(r io.Reader, maxSize int) ReadCloser {
 	return &uvarintReader{bufio.NewReader(r), nil, maxSize, closer}
 }
 
-func NewDelimitedReaderWithSizedBuffer(r io.Reader, maxSize int) ReadCloser {
+// NewDelimitedReaderWithSize creates a protoio ReadCloser with a bufio.Reader
+// sized to `maxSize`
+func NewDelimitedReaderWithSize(r io.Reader, maxSize int) ReadCloser {
 	var closer io.Closer
 	if c, ok := r.(io.Closer); ok {
 		closer = c

--- a/protoio/uvarint_reader.go
+++ b/protoio/uvarint_reader.go
@@ -59,14 +59,13 @@ func NewDelimitedReader(r io.Reader, maxSize int) ReadCloser {
 	return &uvarintReader{bufio.NewReader(r), nil, maxSize, closer}
 }
 
-// NewDelimitedReaderWithSize creates a protoio ReadCloser with a bufio.Reader
-// sized to `maxSize`
-func NewDelimitedReaderWithSize(r io.Reader, maxSize int) ReadCloser {
+// NewDelimitedReaderWithSize creates a reader that uses a buffered reader with a minimum buffer size
+func NewDelimitedReaderWithSize(r io.Reader, size int) ReadCloser {
 	var closer io.Closer
 	if c, ok := r.(io.Closer); ok {
 		closer = c
 	}
-	return &uvarintReader{bufio.NewReaderSize(r, maxSize), nil, maxSize, closer}
+	return &uvarintReader{bufio.NewReaderSize(r, size), nil, size, closer}
 }
 
 func (ur *uvarintReader) ReadMsg(msg proto.Message) (err error) {

--- a/protoio/uvarint_reader.go
+++ b/protoio/uvarint_reader.go
@@ -59,6 +59,14 @@ func NewDelimitedReader(r io.Reader, maxSize int) ReadCloser {
 	return &uvarintReader{bufio.NewReader(r), nil, maxSize, closer}
 }
 
+func NewDelimitedReaderWithSizedBuffer(r io.Reader, maxSize int) ReadCloser {
+	var closer io.Closer
+	if c, ok := r.(io.Closer); ok {
+		closer = c
+	}
+	return &uvarintReader{bufio.NewReaderSize(r, maxSize), nil, maxSize, closer}
+}
+
 func (ur *uvarintReader) ReadMsg(msg proto.Message) (err error) {
 	defer func() {
 		if rerr := recover(); rerr != nil {


### PR DESCRIPTION
Bufio allows for creating readers with a pre-specified buffer size. This commit adds an additional function to create a protoio reader with the bufio reader's buffer initialized to the maximum message length.

This is required for the webrtc transport in go-libp2p. We read protobuf messages from datachannels which have a maximum size of 16384 bytes in the [spec](79d34d00568ee66bf0967914d4c3117f70848efd). The internal buffer for the `uvarintReader` is 4096 bytes. The datachannel only allows reading complete messages and will fail with `ErrShortBuffer` when trying to read a partial message. Since the internal buffer of the `bufio.Reader` in `uvarintReader` is less than the maximum message size, we run into a problem where we are unable to read the protobuf messages from the datachannel.